### PR TITLE
Test commit

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
@@ -65,6 +65,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.PrimitiveIterator;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -260,26 +261,26 @@ public class ValuesSourceReaderBenchmark {
             op.addInput(page);
             switch (name) {
                 case "long" -> {
-                    LongVector values = op.getOutput().<LongBlock>getBlock(1).asVector();
+                    LongVector values = Objects.requireNonNull(op.getOutput()).<LongBlock>getBlock(1).asVector();
                     for (int p = 0; p < values.getPositionCount(); p++) {
                         sum += values.getLong(p);
                     }
                 }
                 case "int" -> {
-                    IntVector values = op.getOutput().<IntBlock>getBlock(1).asVector();
+                    IntVector values = Objects.requireNonNull(op.getOutput()).<IntBlock>getBlock(1).asVector();
                     for (int p = 0; p < values.getPositionCount(); p++) {
                         sum += values.getInt(p);
                     }
                 }
                 case "double" -> {
-                    DoubleVector values = op.getOutput().<DoubleBlock>getBlock(1).asVector();
+                    DoubleVector values = Objects.requireNonNull(op.getOutput()).<DoubleBlock>getBlock(1).asVector();
                     for (int p = 0; p < values.getPositionCount(); p++) {
                         sum += (long) values.getDouble(p);
                     }
                 }
                 case "keyword", "stored_keyword" -> {
                     BytesRef scratch = new BytesRef();
-                    BytesRefVector values = op.getOutput().<BytesRefBlock>getBlock(1).asVector();
+                    BytesRefVector values = Objects.requireNonNull(op.getOutput()).<BytesRefBlock>getBlock(1).asVector();
                     for (int p = 0; p < values.getPositionCount(); p++) {
                         BytesRef r = values.getBytesRef(p, scratch);
                         r.offset++;
@@ -327,11 +328,11 @@ public class ValuesSourceReaderBenchmark {
         boolean foundStoredFieldLoader = false;
         ValuesSourceReaderOperator.Status status = (ValuesSourceReaderOperator.Status) op.status();
         for (Map.Entry<String, Integer> e : status.readersBuilt().entrySet()) {
-            if (e.getKey().indexOf("stored_fields") >= 0) {
+            if (e.getKey().contains("stored_fields")) {
                 foundStoredFieldLoader = true;
             }
         }
-        if (name.indexOf("stored") >= 0) {
+        if (name.contains("stored")) {
             if (foundStoredFieldLoader == false) {
                 throw new AssertionError("expected to use a stored field loader but only had: " + status.readersBuilt());
             }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/BeatsMapperBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/BeatsMapperBenchmark.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
@@ -63,7 +64,7 @@ public class BeatsMapperBenchmark {
     }
 
     private static String readCompressedMapping(String resource) throws IOException {
-        try (var in = new GZIPInputStream(BeatsMapperBenchmark.class.getResourceAsStream(resource))) {
+        try (var in = new GZIPInputStream(Objects.requireNonNull(BeatsMapperBenchmark.class.getResourceAsStream(resource)))) {
             return new String(in.readAllBytes(), UTF_8);
         }
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java
@@ -157,7 +157,7 @@ public class AllocationBenchmark {
     }
 
     private int toInt(String v) {
-        return Integer.valueOf(v.trim());
+        return Integer.parseInt(v.trim());
     }
 
     /**

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -99,6 +99,7 @@ public class AggConstructionContentionBenchmark {
         }
     );
 
+
     private CircuitBreakerService breakerService;
     private BigArrays bigArrays;
     private boolean preallocateBreaker;
@@ -140,6 +141,15 @@ public class AggConstructionContentionBenchmark {
     public void termsSixtySums() throws IOException {
         TermsAggregationBuilder b = new TermsAggregationBuilder("t").field("int_1");
         for (int i = 0; i < 60; i++) {
+            b.subAggregation(new SumAggregationBuilder("s" + i).field("int_" + i));
+        }
+        buildFactories(new AggregatorFactories.Builder().addAggregator(b));
+    }
+
+    @Benchmark
+    public void termsHundredSums() throws IOException {
+        TermsAggregationBuilder b = new TermsAggregationBuilder("t").field("int_1");
+        for (int i = 0; i < 100; i++) {
             b.subAggregation(new SumAggregationBuilder("s" + i).field("int_" + i));
         }
         buildFactories(new AggregatorFactories.Builder().addAggregator(b));

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/TermsReduceBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/TermsReduceBenchmark.java
@@ -130,7 +130,7 @@ public class TermsReduceBenchmark {
                 buckets.add(new StringTerms.Bucket(term, rand.nextInt(10000), subAggs, true, 0L, DocValueFormat.RAW));
             }
 
-            Collections.sort(buckets, (a, b) -> a.compareKey(b));
+            buckets.sort(StringTerms.Bucket::compareKey);
             return new StringTerms(
                 "terms",
                 BucketOrder.key(true),
@@ -196,8 +196,8 @@ public class TermsReduceBenchmark {
             exc -> {}
         );
         CountDownLatch latch = new CountDownLatch(shards.size());
-        for (int i = 0; i < shards.size(); i++) {
-            consumer.consumeResult(shards.get(i), () -> latch.countDown());
+        for (QuerySearchResult shard : shards) {
+            consumer.consumeResult(shard, latch::countDown);
         }
         latch.await();
         SearchPhaseController.ReducedQueryPhase phase = consumer.reduce();

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -85,7 +86,7 @@ public class FilterContentBenchmark {
             case "10_field" -> keys.stream().filter(key -> count.getAndIncrement() % 5 == 0).limit(10).collect(Collectors.toSet());
             case "half_field" -> keys.stream().filter(key -> count.getAndIncrement() % 2 == 0).collect(Collectors.toSet());
             case "all_field" -> new HashSet<>(keys);
-            case "wildcard_field" -> new HashSet<>(Arrays.asList("*stats"));
+            case "wildcard_field" -> new HashSet<>(List.of("*stats"));
             case "10_wildcard_field" -> Set.of(
                 "*stats.nodes*",
                 "*stats.ind*",

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/SnippetLengthCheck.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/SnippetLengthCheck.java
@@ -39,7 +39,7 @@ public class SnippetLengthCheck extends AbstractFileSetCheck {
 
     @Override
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
-        checkFile((line, message) -> log(line, message), max, fileText.toLinesArray());
+        checkFile(this::log, max, fileText.toLinesArray());
     }
 
     static void checkFile(BiConsumer<Integer, String> log, int max, String... lineArray) {

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java
@@ -116,7 +116,8 @@ public class GitInfo {
                 } else {
                     File refsDir = gitDir.resolve("refs").toFile();
                     if (refsDir.exists()) {
-                        String foundRefs = Arrays.stream(Objects.requireNonNull(refsDir.listFiles())).map(File::getName).collect(Collectors.joining("\n"));
+                        File[] files = Objects.requireNonNull(refsDir.listFiles());
+                        String foundRefs = Arrays.stream(files).map(File::getName).collect(Collectors.joining("\n"));
                         Logging.getLogger(GitInfo.class).error("Found git refs\n" + foundRefs);
                     } else {
                         Logging.getLogger(GitInfo.class).error("No git refs dir found");

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -115,7 +116,7 @@ public class GitInfo {
                 } else {
                     File refsDir = gitDir.resolve("refs").toFile();
                     if (refsDir.exists()) {
-                        String foundRefs = Arrays.stream(refsDir.listFiles()).map(f -> f.getName()).collect(Collectors.joining("\n"));
+                        String foundRefs = Arrays.stream(Objects.requireNonNull(refsDir.listFiles())).map(File::getName).collect(Collectors.joining("\n"));
                         Logging.getLogger(GitInfo.class).error("Found git refs\n" + foundRefs);
                     } else {
                         Logging.getLogger(GitInfo.class).error("No git refs dir found");
@@ -176,7 +177,7 @@ public class GitInfo {
     /** Find the reponame. */
     public String urlFromOrigin() {
         if (origin == null) {
-            return null; // best effort, the url doesnt really matter, it is just required by maven central
+            return null; // best effort, the url doesn't really matter, it is just required by maven central
         }
         if (origin.startsWith("https")) {
             return origin;
@@ -185,7 +186,7 @@ public class GitInfo {
         if (matcher.matches()) {
             return String.format("https://%s/%s", matcher.group(1), matcher.group(2));
         } else {
-            return origin; // best effort, the url doesnt really matter, it is just required by maven central
+            return origin; // best effort, the url doesn't really matter, it is just required by maven central
         }
     }
 


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR includes several enhancements and error handling improvements:
- Added null safety checks using `Objects.requireNonNull()` in various places to prevent potential NullPointerExceptions.
- Replaced `Integer.valueOf(v.trim())` with `Integer.parseInt(v.trim())` for integer conversion.
- Added a new benchmark `termsHundredSums()` in `AggConstructionContentionBenchmark.java`.
- Replaced the traditional for loop with an enhanced for loop in `TermsReduceBenchmark.java`.
- Replaced `Collections.sort` with `List.sort` in `TermsReduceBenchmark.java`.
- Replaced `Arrays.asList` with `List.of` for creating a list in `FilterContentBenchmark.java`.
- Replaced lambda with method reference in `SnippetLengthCheck.java`.
- Corrected some comments in `GitInfo.java`.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ValuesSourceReaderBenchmark.java&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java<br><br>

**Added null safety checks using `Objects.requireNonNull()` <br>for `op.getOutput()`. Replaced `indexOf` with `contains` for <br>string matching.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/OlenaProkip/elasticsearch/pull/1/files#diff-b4449d799355af9c1345bd2c523c3b6ad62e4ac021f41f5899c6595115c8e230"> +7/-6</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeatsMapperBenchmark.java&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/BeatsMapperBenchmark.java<br><br>

**Added null safety check using `Objects.requireNonNull()` for <br>`getResourceAsStream(resource)`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/OlenaProkip/elasticsearch/pull/1/files#diff-e44bbc3d84ad46e9a1f3a6be275e6cd3eea5a8afff15d4c2b4fd5423d4a58968"> +2/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GitInfo.java&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java<br><br>

**Added null safety check using `Objects.requireNonNull()` for <br>`refsDir.listFiles()`. Corrected some comments.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/OlenaProkip/elasticsearch/pull/1/files#diff-0898f1b42fd4d93a2cad931e8499603515e053e73007e20b2a33990879020a73"> +4/-3</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>AllocationBenchmark.java&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java<br><br>

**Replaced `Integer.valueOf(v.trim())` with <br>`Integer.parseInt(v.trim())` for integer conversion.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/OlenaProkip/elasticsearch/pull/1/files#diff-38bb01956029aba931b3513d004d0e47f085cc62de54659e4774359897cc6a35"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AggConstructionContentionBenchmark.java&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java<br><br>

**Added a new benchmark `termsHundredSums()`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/OlenaProkip/elasticsearch/pull/1/files#diff-be035e647df5f6b4f46ae1f11b8c0036faa0af3922b6bdacf8fbd768d62cbda6"> +10/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TermsReduceBenchmark.java&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/TermsReduceBenchmark.java<br><br>

**Replaced the traditional for loop with an enhanced for loop. <br>Replaced `Collections.sort` with `List.sort`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/OlenaProkip/elasticsearch/pull/1/files#diff-dc954fb77f17fa147452995926585a2bb1b73aa5b15e1a9c2d7a51ff103866d5"> +3/-3</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FilterContentBenchmark.java&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/FilterContentBenchmark.java<br><br>

**Replaced `Arrays.asList` with `List.of` for creating a list.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/OlenaProkip/elasticsearch/pull/1/files#diff-07e088c0698b9fe3c63fcb97c7199fb4ec4e17ec2700df7b0f011c06a117f186"> +2/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SnippetLengthCheck.java&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/SnippetLengthCheck.java<br><br>

**Replaced lambda with method reference in `checkFile` method.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/OlenaProkip/elasticsearch/pull/1/files#diff-7e39844b3230ea5a5445697f647d5689c05f6d04622cea083d597ecba31c7696"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
test
